### PR TITLE
Change wrong typo

### DIFF
--- a/docs/bool.md
+++ b/docs/bool.md
@@ -12,7 +12,7 @@ Checks for true
 ```es6
 import {validate, bool} from 'valid.js'
 
-let isvalid = validate(number.isTrue)
+let isvalid = validate(bool.isTrue)
 let result = isvalid(true)
 // result => true
 let resultFalse = isvalid(false)
@@ -27,7 +27,7 @@ Checks for false
 ```es6
 import {validate, bool} from 'valid.js'
 
-let isvalid = validate(number.isFalse)
+let isvalid = validate(bool.isFalse)
 let result = isvalid(false)
 // result => true
 let resultFalse = isvalid(true)


### PR DESCRIPTION
Hi @dleitee 

I've noted that in *bool* docs, there are a wrong typo using 'number' instead of 'bool'.

Thanks for all ;)